### PR TITLE
Add Support for Filtering Past Classes and Courses via Query Parameters

### DIFF
--- a/src/features/classes/class.controller.js
+++ b/src/features/classes/class.controller.js
@@ -21,10 +21,18 @@ async function getClasses(userId, options = {}) {
     }
 
     // Build query
-    const query = {
+    let query = {
       userId,
-      startTime: { $gte: startDate, $lte: endDate },
     };
+
+    // Handle past parameter
+    if (options.past === 'true') {
+      // For past classes, get classes that have ended (endTime < current date)
+      query.endTime = { $lt: today };
+    } else {
+      // For current/future classes, use the date range filter
+      query.startTime = { $gte: startDate, $lte: endDate };
+    }
 
     // Execute query
     let classQuery = Class.find(query);

--- a/src/features/classes/routes/get.js
+++ b/src/features/classes/routes/get.js
@@ -12,12 +12,18 @@ import { getClasses } from '../class.controller.js';
  *
  *     ### Example API calls:
  *     - Get all classes: `GET /api/v1/classes`
+ *     - Get past classes: `GET /api/v1/classes?past=true`
  *     - Expand course details: `GET /api/v1/classes?expand=course`
  *     - Filter by date range: `GET /api/v1/classes?from=2023-09-01T00:00:00Z&to=2023-12-31T23:59:59Z`
  *     - Combine expansion with date filtering: `GET /api/v1/classes?expand=course&from=2023-09-01T00:00:00Z&to=2023-12-31T23:59:59Z`
  *   security:
  *    - BearerAuth: []
  *   parameters:
+ *    - in: query
+ *      name: past
+ *      schema:
+ *       type: boolean
+ *      description: Optional parameter to get past classes (classes that have ended)
  *    - in: query
  *      name: from
  *      schema:
@@ -134,6 +140,7 @@ export default (router) => {
       from: req.query.from,
       to: req.query.to,
       expand: req.query.expand,
+      past: req.query.past,
     };
 
     const { success, status, errors, classes } = await getClasses(userId, options);

--- a/src/features/courses/routes/get.js
+++ b/src/features/courses/routes/get.js
@@ -8,7 +8,13 @@ export default (router) => {
    *   tags:
    *    - Courses
    *   summary: Get courses for the authenticated user
-   *   description: Retrieve all courses for the authenticated user, filtered by their completion status. Each course includes its current grade, if available.
+   *   description: |
+   *     Retrieve all courses for the authenticated user, filtered by their completion status. Each course includes its current grade, if available.
+   *
+   *     ### Example API calls:
+   *     - Get active courses: `GET /api/v1/courses`
+   *     - Get completed courses: `GET /api/v1/courses?active=false`
+   *     - Get past courses: `GET /api/v1/courses?past=true`
    *   security:
    *    - BearerAuth: []
    *   parameters:
@@ -18,6 +24,12 @@ export default (router) => {
    *      schema:
    *       type: boolean
    *       default: true
+   *    - in: query
+   *      name: past
+   *      description: Filter courses that have ended (endDate < current date)
+   *      schema:
+   *       type: boolean
+   *       default: false
    *   responses:
    *    '200':
    *      description: Successfully retrieved courses
@@ -45,11 +57,12 @@ export default (router) => {
    */
   router.get('/', async (req, res) => {
     const userId = req.user.userId;
-    const { active } = req.query;
+    const { active, past } = req.query;
 
     const { success, status, errors, courses } = await getCourses(
       userId,
-      active ? JSON.parse(active) : undefined
+      active ? JSON.parse(active) : undefined,
+      past ? JSON.parse(past) : false
     );
 
     if (!success) {
@@ -58,4 +71,4 @@ export default (router) => {
 
     return res.status(200).json({ success: true, courses });
   });
-}
+};


### PR DESCRIPTION
This PR enhances the /classes and /courses endpoints by adding a past=true query parameter, allowing users to filter for past classes (classes that have already ended) and past courses (courses with end dates earlier than today). It also includes updates to controller logic and OpenAPI documentation to reflect the new filtering behavior.