### PR TITLE
Add advanced filtering support: courseID, type, and date range

### DIFF
--- a/src/features/events/event.controller.js
+++ b/src/features/events/event.controller.js
@@ -8,18 +8,34 @@ import Course from '../../shared/models/course.model.js';
 
 async function getEvents(
   userId,
+  courseID = null,
+  type = null,
   isCompleted = false,
   expandCourse = false,
   fromDate = null,
   toDate = null,
 ) {
   logger.debug(
-    `Fetching events for user ${userId} with isCompleted=${isCompleted}, expandCourse=${expandCourse}, fromDate=${fromDate}, toDate=${toDate}`,
+    `Fetching events for user ${userId} 
+    with courseID=${courseID}, 
+    type=${type},
+    isCompleted=${isCompleted}, 
+    expandCourse=${expandCourse}, 
+    fromDate=${fromDate}, 
+    toDate=${toDate}`,
   );
 
   try {
     // Build the query with required filters
     const query = { userId, isCompleted };
+
+    if (courseID) {
+      query.courseID = courseID;
+    }
+
+    if (type) {
+      query.type = type;
+    }
 
     // Add date range filter if provided
     if (fromDate || toDate) {

--- a/src/features/events/routes/get.js
+++ b/src/features/events/routes/get.js
@@ -161,6 +161,8 @@ export default (router) => {
    */
   router.get('/', async (req, res) => {
     const userId = req.user.userId;
+    const courseID = req.query.courseID || null;
+    const type = req.query.type || null;
     const isCompleted = req.query.completed === 'true';
     const expandCourse = req.query.expand === 'course';
     const fromDate = req.query.from || null;
@@ -168,6 +170,8 @@ export default (router) => {
 
     const { success, status, errors, events } = await getEvents(
       userId,
+      courseID,
+      type,
       isCompleted,
       expandCourse,
       fromDate,
@@ -335,6 +339,8 @@ export default (router) => {
    */
   router.get('/:status', async (req, res) => {
     const userId = req.user.userId;
+    const courseID = req.query.courseID || null;
+    const type = req.query.type || null;
     const eventStatus = req.params.status;
     const expandCourse = req.query.expand === 'course';
     const fromDate = req.query.from || null;
@@ -342,6 +348,8 @@ export default (router) => {
 
     const { success, status, errors, events } = await getEvents(
       userId,
+      courseID,
+      type,
       eventStatus === 'completed',
       expandCourse,
       fromDate,


### PR DESCRIPTION
This PR enhances the API's filtering capabilities by introducing support for:

**Course Expansion**
- `expand=course`: Expands and includes course details in the response.

**Date Range Filtering**
- `from=<date>`: Retrieves items on or after the specified date.
- `to=<date>`: Retrieves items on or before the specified date.

**Course Filtering**
- `courseID=<courseID>`: Returns items associated with the specified course.

**Type Filtering**

- `type=<type>`: Retrieves events only for queried type.

**Example Query**
`GET /api/v1/events/completed?expand=course`

**You can combine with other filters:**
`GET /api/events/completed?expand=course&from=2025-06-01T00:00:00Z&to=2025-07-01T00:00:00Z&type=assignment`